### PR TITLE
docs: align phase status in README and ticket index

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ charlottesweb-app/
 | **Phase 0** | Foundation (domain model, backend skeleton, schema) | **Complete** |
 | **Phase 1** | HIPAA Intelligence Engine (intake, mapping, correlation, scoring) | **Complete** |
 | **Phase 2** | Audit Evidence Automation (templates, checklists, binder export) | **In Progress** (50%) |
-| **Phase 3** | Web App Workflows (auth, UI, dashboard, reports) | Not Started |
+| **Phase 3** | Web App Workflows (auth, UI, dashboard, reports) | **In Progress** (MVP UI / partial workflows) |
 | **Phase 4** | Pilot Readiness (isolation, observability, onboarding) | Not Started |
 | **Phase 5** | Continuous Monitoring (scheduled jobs, delta alerts, trends) | Not Started |
 

--- a/docs/tickets/TICKET_INDEX.md
+++ b/docs/tickets/TICKET_INDEX.md
@@ -1,11 +1,11 @@
 # Ticket Index
 
-## Foundation
+## Phase 0 - Foundation ✅ **COMPLETE**
 - CW-001: Define domain model and architecture decisions
 - CW-002: Bootstrap backend service skeleton
 - CW-003: Create initial persistence schema
 
-## Phase 1 – HIPAA Intelligence Engine
+## Phase 1 – HIPAA Intelligence Engine ✅ **COMPLETE**
 - CW-101: Build metadata intake API
 - CW-102: Implement HIPAA control catalog seed
 - CW-103: Implement rules mapping engine
@@ -13,24 +13,24 @@
 - CW-105: Add risk scoring and prioritization
 - CW-106: Generate remediation roadmap output
 
-## Phase 2 – Audit Evidence Automation
+## Phase 2 – Audit Evidence Automation 🚧 **IN PROGRESS** (50%)
 - CW-201: Control-to-evidence mapping model
 - CW-202: Evidence checklist generation
 - CW-203: Policy/document templates generation
 - CW-204: Audit binder export endpoint
 
-## Phase 3 – Web App Workflows
+## Phase 3 – Web App Workflows 🚧 **IN PROGRESS** (MVP UI / partial workflows)
 - CW-301: Auth and organization onboarding
 - CW-302: Assessment run workflow UI
 - CW-303: Findings dashboard and filters
 - CW-304: Report download and share flow
 
-## Phase 4 – Pilot Readiness
+## Phase 4 – Pilot Readiness ⏸️ **NOT STARTED**
 - CW-401: Tenant isolation guardrails
 - CW-402: Observability and audit logging
 - CW-403: Pilot onboarding scripts and demo data
 
-## Phase 5 – Continuous Monitoring
+## Phase 5 – Continuous Monitoring ⏸️ **NOT STARTED**
 - CW-501: Scheduled re-assessment jobs
 - CW-502: Delta risk detection and alerts
 - CW-503: Posture timeline and trend reporting


### PR DESCRIPTION
## Summary\n- update README phase table to mark Phase 3 as in progress\n- align docs/tickets/TICKET_INDEX.md phase statuses with current roadmap\n\n## Why\nDocumentation should reflect the current implementation state before continuing Phase 3 work.