### PR TITLE
feat(phase3): add organization onboarding API with role model

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -46,6 +46,7 @@ from src.models import (
     Finding,
     MetadataProfile,
     Organization,
+    OrganizationMember,
 )
 
 logger = logging.getLogger(__name__)
@@ -53,6 +54,7 @@ logger = logging.getLogger(__name__)
 # Import model classes so SQLAlchemy registers all tables before create_all()
 REGISTERED_MODEL_CLASSES = (
     Organization,
+    OrganizationMember,
     MetadataProfile,
     Control,
     Assessment,

--- a/src/models.py
+++ b/src/models.py
@@ -1,4 +1,5 @@
 """Database models for CharlottesWeb."""
+
 from datetime import UTC, datetime
 from uuid import uuid4
 
@@ -36,6 +37,30 @@ class Organization(Base):
     # Relationships
     metadata_profiles = relationship("MetadataProfile", back_populates="organization")
     assessments = relationship("Assessment", back_populates="organization")
+    members = relationship("OrganizationMember", back_populates="organization")
+
+
+class OrganizationMember(Base):
+    """Organization member used for onboarding and role assignment."""
+
+    __tablename__ = "organization_members"
+
+    id = Column(String, primary_key=True, default=generate_uuid)
+    organization_id = Column(
+        String, ForeignKey("organizations.id"), nullable=False, index=True
+    )
+    email = Column(String, nullable=False)
+    full_name = Column(String, nullable=True)
+    role = Column(String, nullable=False, default="member", index=True)  # admin, member
+    created_at = Column(DateTime, default=utcnow, nullable=False)
+
+    # Relationships
+    organization = relationship("Organization", back_populates="members")
+
+    __table_args__ = (
+        Index("idx_org_members_org_id", "organization_id"),
+        Index("idx_org_members_role", "role"),
+    )
 
 
 class MetadataProfile(Base):
@@ -44,7 +69,9 @@ class MetadataProfile(Base):
     __tablename__ = "metadata_profiles"
 
     id = Column(String, primary_key=True, default=generate_uuid)
-    organization_id = Column(String, ForeignKey("organizations.id"), nullable=False, index=True)
+    organization_id = Column(
+        String, ForeignKey("organizations.id"), nullable=False, index=True
+    )
 
     # Metadata fields (stored as JSON for flexibility)
     phi_types = Column(JSON, nullable=True)  # list of PHI categories
@@ -92,10 +119,16 @@ class Assessment(Base):
     __tablename__ = "assessments"
 
     id = Column(String, primary_key=True, default=generate_uuid)
-    organization_id = Column(String, ForeignKey("organizations.id"), nullable=False, index=True)
-    metadata_profile_id = Column(String, ForeignKey("metadata_profiles.id"), nullable=False, index=True)
+    organization_id = Column(
+        String, ForeignKey("organizations.id"), nullable=False, index=True
+    )
+    metadata_profile_id = Column(
+        String, ForeignKey("metadata_profiles.id"), nullable=False, index=True
+    )
 
-    status = Column(String, default="pending", nullable=False, index=True)  # pending, running, completed, failed
+    status = Column(
+        String, default="pending", nullable=False, index=True
+    )  # pending, running, completed, failed
     initiated_at = Column(DateTime, default=utcnow, nullable=False)
     completed_at = Column(DateTime, nullable=True)
 
@@ -119,19 +152,27 @@ class Finding(Base):
     __tablename__ = "findings"
 
     id = Column(String, primary_key=True, default=generate_uuid)
-    assessment_id = Column(String, ForeignKey("assessments.id"), nullable=False, index=True)
-    control_id = Column(String, ForeignKey("controls.id"), nullable=True, index=True)  # nullable for NVD findings
+    assessment_id = Column(
+        String, ForeignKey("assessments.id"), nullable=False, index=True
+    )
+    control_id = Column(
+        String, ForeignKey("controls.id"), nullable=True, index=True
+    )  # nullable for NVD findings
 
     title = Column(String, nullable=False)
     description = Column(Text, nullable=False)
-    severity = Column(String, nullable=False, index=True)  # immediate, high, medium, low
+    severity = Column(
+        String, nullable=False, index=True
+    )  # immediate, high, medium, low
     cvss_score = Column(Float, nullable=True)
     external_id = Column(String, nullable=True)  # CVE ID for NVD findings
     cve_ids = Column(JSON, nullable=True)  # list of CVE IDs
     cwe_ids = Column(JSON, nullable=True)  # list of CWE IDs
 
     remediation_guidance = Column(Text, nullable=True)
-    priority_window = Column(String, nullable=True)  # immediate, 30_days, quarterly, annual
+    priority_window = Column(
+        String, nullable=True
+    )  # immediate, 30_days, quarterly, annual
     owner = Column(String, nullable=True)  # DevOps, Engineering, Security
 
     created_at = Column(DateTime, default=utcnow, nullable=False)
@@ -156,15 +197,21 @@ class Evidence(Base):
 
     id = Column(String, primary_key=True, default=generate_uuid)
     control_id = Column(String, ForeignKey("controls.id"), nullable=False, index=True)
-    assessment_id = Column(String, ForeignKey("assessments.id"), nullable=True, index=True)
+    assessment_id = Column(
+        String, ForeignKey("assessments.id"), nullable=True, index=True
+    )
 
     # Evidence classification
-    evidence_type = Column(String, nullable=False)  # policy, config, screenshot, logs, etc.
+    evidence_type = Column(
+        String, nullable=False
+    )  # policy, config, screenshot, logs, etc.
     title = Column(String, nullable=False)
     description = Column(Text, nullable=True)
 
     # Status tracking
-    status = Column(String, default="not_started", nullable=False, index=True)  # not_started, in_progress, completed, not_applicable
+    status = Column(
+        String, default="not_started", nullable=False, index=True
+    )  # not_started, in_progress, completed, not_applicable
     owner = Column(String, nullable=True)  # responsible party
     due_date = Column(DateTime, nullable=True)
 
@@ -173,7 +220,9 @@ class Evidence(Base):
     artifact_url = Column(String, nullable=True)  # external URL if applicable
     artifact_hash = Column(String, nullable=True)  # SHA256 for integrity
     uploaded_at = Column(DateTime, nullable=True)
-    collected_at = Column(DateTime, nullable=True)  # when evidence was actually collected
+    collected_at = Column(
+        DateTime, nullable=True
+    )  # when evidence was actually collected
 
     # Versioning
     version = Column(String, default="1", nullable=False)

--- a/src/routers/organizations.py
+++ b/src/routers/organizations.py
@@ -1,4 +1,5 @@
 """Organization management endpoints."""
+
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -8,8 +9,13 @@ from src.audit import AuditAction, log_audit_event
 from src.config import settings
 from src.database import get_db, get_or_404
 from src.middleware import get_api_key_optional, limiter
-from src.models import Organization
-from src.schemas import OrganizationCreate, OrganizationResponse
+from src.models import Organization, OrganizationMember
+from src.schemas import (
+    OrganizationCreate,
+    OrganizationOnboardingCreate,
+    OrganizationOnboardingResponse,
+    OrganizationResponse,
+)
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/organizations", tags=["organizations"])
@@ -40,7 +46,7 @@ def create_organization(
         # Return safe error message to client
         raise HTTPException(
             status_code=500,
-            detail="Failed to create organization. Please ensure the application has write access and try again."
+            detail="Failed to create organization. Please ensure the application has write access and try again.",
         ) from e
 
     # Audit log
@@ -54,6 +60,60 @@ def create_organization(
     )
 
     return org
+
+
+@router.post("/onboard", response_model=OrganizationOnboardingResponse, status_code=201)
+@limiter.limit(f"{settings.rate_limit_per_minute}/minute")
+def onboard_organization(
+    request: Request,
+    onboarding_data: OrganizationOnboardingCreate,
+    db: Session = Depends(get_db),
+    api_key: str = Depends(get_api_key_optional),
+) -> OrganizationOnboardingResponse:
+    """Create a new organization and first member in a single onboarding flow."""
+    try:
+        org = Organization(
+            name=onboarding_data.name,
+            industry=onboarding_data.industry,
+            stage=onboarding_data.stage,
+        )
+        db.add(org)
+        db.flush()
+
+        member = OrganizationMember(
+            organization_id=org.id,  # type: ignore[arg-type] - SQLAlchemy Column unwraps at runtime
+            email=onboarding_data.admin_email,
+            full_name=onboarding_data.admin_name,
+            role=onboarding_data.admin_role,
+        )
+        db.add(member)
+        db.commit()
+        db.refresh(org)
+        db.refresh(member)
+    except Exception as e:
+        db.rollback()
+        logger.error(f"Failed to onboard organization: {str(e)}", exc_info=True)
+        raise HTTPException(
+            status_code=500,
+            detail="Failed to onboard organization. Please ensure the application has write access and try again.",
+        ) from e
+
+    log_audit_event(
+        action=AuditAction.ORG_CREATED,
+        request=request,
+        api_key=api_key,
+        resource_type="organization",
+        resource_id=org.id,  # type: ignore[arg-type] - SQLAlchemy Column unwraps at runtime
+        details={
+            "name": org.name,
+            "industry": org.industry,
+            "onboarding": True,
+            "member_email": member.email,
+            "member_role": member.role,
+        },
+    )
+
+    return OrganizationOnboardingResponse(organization=org, member=member)
 
 
 @router.get("/{org_id}", response_model=OrganizationResponse)

--- a/src/schemas.py
+++ b/src/schemas.py
@@ -1,6 +1,7 @@
 """Pydantic schemas for API request/response validation."""
+
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
@@ -24,6 +25,37 @@ class OrganizationResponse(BaseModel):
     created_at: datetime
 
     model_config = {"from_attributes": True}
+
+
+class OrganizationMemberResponse(BaseModel):
+    """Schema for organization member response."""
+
+    id: str
+    organization_id: str
+    email: str
+    full_name: str | None = None
+    role: str
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class OrganizationOnboardingCreate(BaseModel):
+    """Schema for onboarding a new organization with first member."""
+
+    name: str = Field(..., min_length=1, max_length=255)
+    industry: str | None = None
+    stage: str | None = None
+    admin_email: str = Field(..., min_length=3, max_length=255)
+    admin_name: str | None = Field(default=None, max_length=255)
+    admin_role: Literal["admin", "member"] = "admin"
+
+
+class OrganizationOnboardingResponse(BaseModel):
+    """Schema for onboarding response."""
+
+    organization: OrganizationResponse
+    member: OrganizationMemberResponse
 
 
 # Metadata Profile schemas
@@ -123,7 +155,9 @@ class ThreatTechnique(BaseModel):
 class ThreatContext(BaseModel):
     """Schema for threat intelligence context added to findings."""
 
-    techniques: list[ThreatTechnique] = Field(description="Attack techniques that exploit this gap")
+    techniques: list[ThreatTechnique] = Field(
+        description="Attack techniques that exploit this gap"
+    )
     summary: str = Field(description="Executive summary of threat")
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,5 @@
 """Tests for CharlottesWeb API."""
+
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
@@ -25,6 +26,7 @@ def test_db(tmp_path):
     # Seed controls
     db = testing_session_local()
     from src.models import Control
+
     controls = [
         Control(
             id="HIPAA.164.312(a)(1)",
@@ -82,12 +84,36 @@ def test_create_organization(client):
     """Test creating an organization."""
     response = client.post(
         "/api/v1/organizations",
-        json={"name": "Test Health Startup", "industry": "digital_health", "stage": "seed"},
+        json={
+            "name": "Test Health Startup",
+            "industry": "digital_health",
+            "stage": "seed",
+        },
     )
     assert response.status_code == 201
     data = response.json()
     assert data["name"] == "Test Health Startup"
     assert "id" in data
+
+
+def test_onboard_organization(client):
+    """Test onboarding organization with initial admin member."""
+    response = client.post(
+        "/api/v1/organizations/onboard",
+        json={
+            "name": "Onboarded Health Startup",
+            "industry": "digital_health",
+            "stage": "seed",
+            "admin_email": "founder@example.com",
+            "admin_name": "Founder",
+            "admin_role": "admin",
+        },
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["organization"]["name"] == "Onboarded Health Startup"
+    assert data["member"]["email"] == "founder@example.com"
+    assert data["member"]["role"] == "admin"
 
 
 def test_create_metadata_profile(client):

--- a/tests/test_comprehensive.py
+++ b/tests/test_comprehensive.py
@@ -1,4 +1,5 @@
 """Comprehensive tests for CharlottesWeb API - Phase 3 test coverage expansion."""
+
 from unittest.mock import patch
 
 import pytest
@@ -171,6 +172,36 @@ class TestOrganizations:
         """Test 404 when organization does not exist."""
         response = client.get("/api/v1/organizations/nonexistent-id")
         assert response.status_code == 404
+
+    def test_onboard_organization_with_member_role(self, client):
+        """Test onboarding endpoint supports valid role values."""
+        response = client.post(
+            "/api/v1/organizations/onboard",
+            json={
+                "name": "Role Test Org",
+                "industry": "healthcare",
+                "stage": "growth",
+                "admin_email": "member@example.com",
+                "admin_name": "Member User",
+                "admin_role": "member",
+            },
+        )
+        assert response.status_code == 201
+        data = response.json()
+        assert data["organization"]["name"] == "Role Test Org"
+        assert data["member"]["role"] == "member"
+
+    def test_onboard_organization_invalid_role(self, client):
+        """Test onboarding rejects invalid role values."""
+        response = client.post(
+            "/api/v1/organizations/onboard",
+            json={
+                "name": "Invalid Role Org",
+                "admin_email": "admin@example.com",
+                "admin_role": "owner",
+            },
+        )
+        assert response.status_code == 422
 
 
 # ========== Metadata Profile Tests ==========
@@ -421,7 +452,9 @@ class TestEvidence:
         assert data["control_id"] == "HIPAA.164.312(a)(1)"
         assert data["title"] == "Access Control Policy"
 
-    def test_create_evidence_with_assessment(self, client, org_data, metadata_profile_data):
+    def test_create_evidence_with_assessment(
+        self, client, org_data, metadata_profile_data
+    ):
         """Test creating evidence linked to assessment."""
         # Create assessment
         assess_response = client.post(
@@ -545,9 +578,7 @@ class TestEvidence:
         assessment_id = assess_response.json()["id"]
 
         # Generate checklist
-        response = client.get(
-            f"/api/v1/assessments/{assessment_id}/evidence-checklist"
-        )
+        response = client.get(f"/api/v1/assessments/{assessment_id}/evidence-checklist")
         assert response.status_code == 200
         data = response.json()
         assert "items" in data


### PR DESCRIPTION
## Summary
- add organization member model and role support (admin/member)
- add onboarding endpoint to create org + initial member in one request
- add focused tests for onboarding happy-path and role validation

## Phase mapping
Implements CW-301 (Auth and organization onboarding) backend slice for role model support.

## Validation
- pytest -q tests/test_api.py::test_onboard_organization
- pytest -q tests/test_comprehensive.py::TestOrganizations::test_onboard_organization_with_member_role
- pytest -q tests/test_comprehensive.py::TestOrganizations::test_onboard_organization_invalid_role