### PR TITLE
feat(phase3): add assessment run status and progress visibility

### DIFF
--- a/src/routers/assessments.py
+++ b/src/routers/assessments.py
@@ -30,6 +30,7 @@ from src.rules_engine import RulesEngine
 from src.schemas import (
     AssessmentCreate,
     AssessmentResponse,
+    AssessmentStatusResponse,
     ComplianceAsCodeResponse,
     EvidenceChecklistItem,
     EvidenceChecklistResponse,
@@ -446,6 +447,51 @@ def get_assessment(assessment_id: str, db: Session = Depends(get_db)) -> Assessm
     """Get assessment by ID."""
     assessment = get_or_404(db, Assessment, assessment_id, "Assessment not found")
     return assessment
+
+
+@router.get("/{assessment_id}/status", response_model=AssessmentStatusResponse)
+def get_assessment_status(
+    assessment_id: str,
+    db: Session = Depends(get_db),
+) -> AssessmentStatusResponse:
+    """Get assessment run status with coarse-grained progress for UI workflows."""
+    assessment = get_or_404(db, Assessment, assessment_id, "Assessment not found")
+
+    findings_count = (
+        db.query(Finding)
+        .filter(Finding.assessment_id == assessment_id)  # type: ignore[attr-defined]
+        .count()
+    )
+
+    status = _to_str(getattr(assessment, "status", None), default="pending")
+    completed_at = getattr(assessment, "completed_at", None)
+    initiated_at = getattr(assessment, "initiated_at", None)
+
+    if status == AssessmentStatus.COMPLETED:
+        progress_percent = 100
+        current_step = "Assessment complete"
+        updated_at = completed_at
+    elif status == AssessmentStatus.FAILED:
+        progress_percent = 100
+        current_step = "Assessment failed"
+        updated_at = completed_at or initiated_at
+    elif status == AssessmentStatus.RUNNING:
+        progress_percent = 60
+        current_step = "Assessment running"
+        updated_at = initiated_at
+    else:
+        progress_percent = 20
+        current_step = "Assessment queued"
+        updated_at = initiated_at
+
+    return AssessmentStatusResponse(
+        assessment_id=assessment_id,
+        status=status,
+        progress_percent=progress_percent,
+        current_step=current_step,
+        findings_count=findings_count,
+        updated_at=updated_at,
+    )
 
 
 @router.get(

--- a/src/schemas.py
+++ b/src/schemas.py
@@ -123,6 +123,17 @@ class AssessmentResponse(BaseModel):
     model_config = {"from_attributes": True}
 
 
+class AssessmentStatusResponse(BaseModel):
+    """Schema for assessment run status and progress."""
+
+    assessment_id: str
+    status: str
+    progress_percent: int
+    current_step: str
+    findings_count: int
+    updated_at: datetime | None = None
+
+
 # Threat Intelligence schemas (MITRE ATT&CK)
 class ThreatTechniqueBreachExample(BaseModel):
     """Schema for real-world breach example."""

--- a/static/index.html
+++ b/static/index.html
@@ -953,7 +953,7 @@
                     throw new Error('Duplicate component names. Each component must be unique.');
                 }
 
-                showLoading('Creating organization...');
+                showLoading('Creating organization...', 20);
 
                 // Step 1: Create organization
                 const orgRes = await fetch('/api/v1/organizations', {
@@ -972,7 +972,7 @@
                 console.log('✅ Organization created:', org.id);
 
                 // Step 2: Create metadata profile
-                showLoading('Creating metadata profile...');
+                showLoading('Creating metadata profile...', 40);
 
                 const profileRes = await fetch('/api/v1/metadata-profiles', {
                     method: 'POST',
@@ -993,7 +993,7 @@
                 console.log('✅ Metadata profile created:', profile.id);
 
                 // Step 3: Create assessment
-                showLoading('Creating assessment...');
+                showLoading('Creating assessment...', 60);
 
                 const assessRes = await fetch('/api/v1/assessments', {
                     method: 'POST',
@@ -1012,8 +1012,18 @@
                 const assess = await assessRes.json();
                 console.log('✅ Assessment created:', assess.id);
 
+                const statusRes = await fetch(`/api/v1/assessments/${assess.id}/status`);
+                let runStatus = null;
+                if (statusRes.ok) {
+                    runStatus = await statusRes.json();
+                    showLoading(
+                        `Assessment status: ${runStatus.status} (${runStatus.current_step})`,
+                        runStatus.progress_percent
+                    );
+                }
+
                 // Step 4: Run NVD analysis
-                showLoading('Querying National Vulnerability Database...');
+                showLoading('Querying National Vulnerability Database...', 80);
 
                 const nvdRes = await fetch(
                     `/api/v1/assessments/${assess.id}/analyze-nvd`,
@@ -1031,8 +1041,13 @@
                 const findings = await nvdRes.json();
                 console.log('✅ NVD analysis complete:', findings.length, 'findings');
 
+                const finalStatusRes = await fetch(`/api/v1/assessments/${assess.id}/status`);
+                if (finalStatusRes.ok) {
+                    runStatus = await finalStatusRes.json();
+                }
+
                 // Display results with notification about auto-selected versions
-                displayResults(stack, findings, org, assess.id, defaultedVersions);
+                displayResults(stack, findings, org, assess.id, defaultedVersions, runStatus);
 
             } catch (err) {
                 showError(err.message);
@@ -1044,10 +1059,22 @@
             })(); // End of async IIFE
         });
 
-        function showLoading(message) {
+        function showLoading(message, progressPercent = null) {
             resultDiv.classList.remove('hidden', 'error', 'success');
             resultDiv.classList.add('loading');
-            resultDiv.innerHTML = `<p>⏳ ${message}</p>`;
+
+            const progressHtml = (typeof progressPercent === 'number')
+                ? `
+                    <div style="max-width: 420px; margin: 12px auto 0 auto; text-align: left;">
+                        <div style="font-size: 12px; color: #555; margin-bottom: 4px;">Progress: ${progressPercent}%</div>
+                        <div style="height: 8px; background: #e9ecef; border-radius: 4px; overflow: hidden;">
+                            <div style="height: 100%; width: ${progressPercent}%; background: #667eea;"></div>
+                        </div>
+                    </div>
+                `
+                : '';
+
+            resultDiv.innerHTML = `<p>⏳ ${message}</p>${progressHtml}`;
         }
 
         function showError(message) {
@@ -1105,7 +1132,7 @@
             });
         }
 
-        function displayResults(stack, findings, org, assessmentId, defaultedVersions = []) {
+        function displayResults(stack, findings, org, assessmentId, defaultedVersions = [], runStatus = null) {
             // Store data for export
             window.currentAssessment = { stack, findings, org, assessmentId };
 
@@ -1129,6 +1156,11 @@
                     <button onclick="exportJSON()" title="Download findings as JSON">📥 Export JSON</button>
                     <button onclick="exportReport()" title="Download human-readable report">📄 Export Report</button>
                 </div>
+                ${runStatus ? `
+                <div style="background: #eef4ff; border-left: 4px solid #667eea; padding: 10px 12px; border-radius: 4px; margin-bottom: 12px; font-size: 14px;">
+                    <strong>Run Status:</strong> ${runStatus.status} • ${runStatus.progress_percent}% • ${runStatus.current_step}<br>
+                    <strong>Assessment ID:</strong> ${runStatus.assessment_id} • <strong>Findings:</strong> ${runStatus.findings_count}
+                </div>` : ''}
                 <div class="stats">
                     <div class="stat-box">
                         <div class="stat-value">${Object.keys(stack).length}</div>
@@ -1315,13 +1347,13 @@
                     const buttonHtml = hasEvidence
                         ? `<button class="edit-evidence-btn" data-evidence-id="${item.evidence_id}" data-status="${item.status}" data-required-evidence="${item.required_evidence.replace(/"/g, '&quot;')}" data-control-title="${item.control_title.replace(/"/g, '&quot;')}" data-collected-at="${item.collected_at || ''}" data-notes="${(item.notes || '').replace(/"/g, '&quot;')}" style="padding: 6px 12px; background: #667eea; color: white; border: none; border-radius: 4px; cursor: pointer; font-size: 12px;">Edit</button>`
                         : `<button disabled style="padding: 6px 12px; background: #ccc; color: #666; border: none; border-radius: 4px; cursor: not-allowed; font-size: 12px;" title="Create evidence record first">No Record</button>`;
-                    
+
                     return `
                         <li class="evidence-item" data-evidence-id="${item.evidence_id || 'none'}">
                             <div style="display: flex; justify-content: space-between; align-items: flex-start;">
                                 <div style="flex: 1;">
                                     <strong>${item.control_title}</strong>
-                                    ${hasEvidence 
+                                    ${hasEvidence
                                         ? `<span class="status-pill ${item.status} edit-status-pill" data-evidence-id="${item.evidence_id}" data-status="${item.status}" data-required-evidence="${item.required_evidence.replace(/"/g, '&quot;')}" data-control-title="${item.control_title.replace(/"/g, '&quot;')}" data-collected-at="${item.collected_at || ''}" data-notes="${(item.notes || '').replace(/"/g, '&quot;')}" style="cursor: pointer;">${item.status.replace('_', ' ')}</span>`
                                         : `<span class="status-pill ${item.status}" style="color: #999;">${item.status.replace('_', ' ')}</span>`
                                     }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -198,3 +198,38 @@ def test_run_assessment(client):
     finding_titles = [f["title"] for f in findings]
     assert "Multi-Factor Authentication (MFA) Not Enabled" in finding_titles
     assert "Encryption at Rest Not Enabled" in finding_titles
+
+
+def test_get_assessment_status(client):
+    """Test assessment status endpoint returns progress details."""
+    org_response = client.post("/api/v1/organizations", json={"name": "Status Org"})
+    org_id = org_response.json()["id"]
+
+    profile_response = client.post(
+        "/api/v1/metadata-profiles",
+        json={
+            "organization_id": org_id,
+            "software_stack": {"openssl": "1.0.1"},
+        },
+    )
+    profile_id = profile_response.json()["id"]
+
+    assessment_response = client.post(
+        "/api/v1/assessments",
+        json={
+            "organization_id": org_id,
+            "metadata_profile_id": profile_id,
+        },
+    )
+    assert assessment_response.status_code == 201
+    assessment_id = assessment_response.json()["id"]
+
+    status_response = client.get(f"/api/v1/assessments/{assessment_id}/status")
+    assert status_response.status_code == 200
+    status_data = status_response.json()
+
+    assert status_data["assessment_id"] == assessment_id
+    assert status_data["status"] == "completed"
+    assert status_data["progress_percent"] == 100
+    assert "current_step" in status_data
+    assert "findings_count" in status_data

--- a/tests/test_comprehensive.py
+++ b/tests/test_comprehensive.py
@@ -298,7 +298,11 @@ class TestAssessments:
         assert response.status_code == 201
         data = response.json()
         assert data["status"] == "completed"
-        assert "id" in data
+
+    def test_get_assessment_status_not_found(self, client):
+        """Test assessment status endpoint returns 404 for unknown assessment."""
+        response = client.get("/api/v1/assessments/nonexistent-assessment/status")
+        assert response.status_code == 404
 
     def test_create_assessment_incomplete_gaps(self, client, org_data):
         """Test assessment with security gaps."""


### PR DESCRIPTION
## Summary
- add assessment status endpoint with progress and current step metadata
- add status response schema for workflow clients
- update web workflow UI to show step-by-step progress and run status details
- add targeted API tests for status endpoint behavior

## Phase mapping
Implements CW-302 acceptance for run status/progress visibility and guided workflow feedback.

## Validation
- pytest -q tests/test_api.py::test_get_assessment_status
- pytest -q tests/test_comprehensive.py::TestAssessments::test_get_assessment_status_not_found