### PR TITLE
docs: sync phase 3 progress and issue focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ charlottesweb-app/
 | **Phase 0** | Foundation (domain model, backend skeleton, schema) | **Complete** |
 | **Phase 1** | HIPAA Intelligence Engine (intake, mapping, correlation, scoring) | **Complete** |
 | **Phase 2** | Audit Evidence Automation (templates, checklists, binder export) | **In Progress** (50%) |
-| **Phase 3** | Web App Workflows (auth, UI, dashboard, reports) | **In Progress** (MVP UI / partial workflows) |
+| **Phase 3** | Web App Workflows (auth, UI, dashboard, reports) | **In Progress** (CW-301/CW-302 complete; CW-303 next) |
 | **Phase 4** | Pilot Readiness (isolation, observability, onboarding) | Not Started |
 | **Phase 5** | Continuous Monitoring (scheduled jobs, delta alerts, trends) | Not Started |
 

--- a/docs/tickets/TICKET_INDEX.md
+++ b/docs/tickets/TICKET_INDEX.md
@@ -19,10 +19,10 @@
 - CW-203: Policy/document templates generation
 - CW-204: Audit binder export endpoint
 
-## Phase 3 – Web App Workflows 🚧 **IN PROGRESS** (MVP UI / partial workflows)
-- CW-301: Auth and organization onboarding
-- CW-302: Assessment run workflow UI
-- CW-303: Findings dashboard and filters
+## Phase 3 – Web App Workflows 🚧 **IN PROGRESS** (CW-301/CW-302 complete)
+- CW-301: Auth and organization onboarding ✅ COMPLETE
+- CW-302: Assessment run workflow UI ✅ COMPLETE
+- CW-303: Findings dashboard and filters 🎯 NEXT FOCUS
 - CW-304: Report download and share flow
 
 ## Phase 4 – Pilot Readiness ⏸️ **NOT STARTED**

--- a/docs/tickets/phase-3-web-app-workflows.md
+++ b/docs/tickets/phase-3-web-app-workflows.md
@@ -3,6 +3,7 @@
 ## CW-301 Auth and organization onboarding
 - Type: Fullstack
 - Priority: P0
+- Status: ✅ Complete (PR #31)
 - Outcome: User auth and organization setup flow.
 - Acceptance:
 - New org can register and create profile
@@ -11,6 +12,7 @@
 ## CW-302 Assessment run workflow UI
 - Type: Frontend
 - Priority: P0
+- Status: ✅ Complete (PR #32)
 - Outcome: Guided form to submit metadata and run assessment.
 - Acceptance:
 - Validation mirrors backend schema
@@ -19,6 +21,7 @@
 ## CW-303 Findings dashboard and filters
 - Type: Frontend
 - Priority: P0
+- Status: 🎯 Next Focus
 - Outcome: Display findings by severity/control/domain.
 - Acceptance:
 - Supports sorting/filtering by priority window
@@ -27,6 +30,7 @@
 ## CW-304 Report download and share flow
 - Type: Frontend/Backend
 - Priority: P1
+- Status: Backlog
 - Outcome: Download executive report and technical appendix.
 - Acceptance:
 - Report generation status visible


### PR DESCRIPTION
## Summary
- update README Phase 3 status to reflect CW-301/CW-302 completion
- update ticket index with completed/next-focus indicators
- update phase-3 ticket doc statuses and focus ordering

## Issue tracker updates (already applied)
- closed #14 (CW-301)
- closed #15 (CW-302)
- added next-focus note on #16 (CW-303)
