### PR TITLE
docs: update phase 3 status after CW-303 completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ charlottesweb-app/
 | **Phase 0** | Foundation (domain model, backend skeleton, schema) | **Complete** |
 | **Phase 1** | HIPAA Intelligence Engine (intake, mapping, correlation, scoring) | **Complete** |
 | **Phase 2** | Audit Evidence Automation (templates, checklists, binder export) | **In Progress** (50%) |
-| **Phase 3** | Web App Workflows (auth, UI, dashboard, reports) | **In Progress** (CW-301/CW-302 complete; CW-303 next) |
+| **Phase 3** | Web App Workflows (auth, UI, dashboard, reports) | **In Progress** (CW-301/CW-302/CW-303 complete; CW-304 next) |
 | **Phase 4** | Pilot Readiness (isolation, observability, onboarding) | Not Started |
 | **Phase 5** | Continuous Monitoring (scheduled jobs, delta alerts, trends) | Not Started |
 

--- a/docs/tickets/TICKET_INDEX.md
+++ b/docs/tickets/TICKET_INDEX.md
@@ -19,11 +19,11 @@
 - CW-203: Policy/document templates generation
 - CW-204: Audit binder export endpoint
 
-## Phase 3 – Web App Workflows 🚧 **IN PROGRESS** (CW-301/CW-302 complete)
+## Phase 3 – Web App Workflows 🚧 **IN PROGRESS** (CW-301/CW-302/CW-303 complete)
 - CW-301: Auth and organization onboarding ✅ COMPLETE
 - CW-302: Assessment run workflow UI ✅ COMPLETE
-- CW-303: Findings dashboard and filters 🎯 NEXT FOCUS
-- CW-304: Report download and share flow
+- CW-303: Findings dashboard and filters ✅ COMPLETE
+- CW-304: Report download and share flow 🎯 NEXT FOCUS
 
 ## Phase 4 – Pilot Readiness ⏸️ **NOT STARTED**
 - CW-401: Tenant isolation guardrails

--- a/docs/tickets/phase-3-web-app-workflows.md
+++ b/docs/tickets/phase-3-web-app-workflows.md
@@ -21,7 +21,7 @@
 ## CW-303 Findings dashboard and filters
 - Type: Frontend
 - Priority: P0
-- Status: 🎯 Next Focus
+- Status: ✅ Complete (PR #34)
 - Outcome: Display findings by severity/control/domain.
 - Acceptance:
 - Supports sorting/filtering by priority window
@@ -30,7 +30,7 @@
 ## CW-304 Report download and share flow
 - Type: Frontend/Backend
 - Priority: P1
-- Status: Backlog
+- Status: 🎯 Next Focus
 - Outcome: Download executive report and technical appendix.
 - Acceptance:
 - Report generation status visible


### PR DESCRIPTION
## Summary
- mark CW-303 complete across roadmap docs
- set CW-304 as active Phase 3 focus
- align README Phase 3 status wording with merged work

## Issue tracker sync
- closed #16 (CW-303)
- added focus note on #17 (CW-304)
