### PR TITLE
Clean up documentation language and fix mypy type error

### DIFF
--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -511,9 +511,9 @@ scripts/
 
 ---
 
-## What the Vertical Slice Demonstrates
+## End-to-End Data Flow (MVP)
 
-This MVP proves the entire data flow:
+This MVP covers the full request cycle:
 
 1. **Metadata Intake** → Organization + MetadataProfile models
 2. **Control Mapping** → 10 seeded HIPAA controls

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ CharlottesWeb automates regulatory mapping by correlating HIPAA requirements wit
 **Production-ready security controls:**
 - API key authentication
 - Rate limiting (60 req/min default)
-- Comprehensive audit logging
+- Audit logging
 - Security headers (HSTS, CSP, etc.)
 - Request tracing
 - Environment-based secrets management
@@ -62,7 +62,7 @@ charlottesweb-app/
 
 ## Getting Started
 
-### For New Contributors or AI Agents
+### For New Contributors
 
 1. **Read the context:**
 - [BUSINESS_PLAN.md](BUSINESS_PLAN.md) - Understand the market, problem, and business model

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Guide
 
-CharlottesWeb implements comprehensive security controls appropriate for a HIPAA compliance platform. This guide covers all security features, configuration, testing, and incident response procedures.
+This guide covers the security controls built into CharlottesWeb, including configuration, testing, and incident response.
 
 ---
 
@@ -12,7 +12,7 @@ CharlottesWeb implements comprehensive security controls appropriate for a HIPAA
 | **JWT Token Auth** | Secure session handling with HS256 signing (PyJWT) | Active |
 | **Rate Limiting** | Prevent abuse with per-IP throttling (60 req/min) | Active |
 | **Security Headers** | 7 HTTP headers protecting against common attacks | Active |
-| **Audit Logging** | JSON structured logs with comprehensive event tracking | Active |
+| **Audit Logging** | JSON structured logs with structured event tracking | Active |
 | **Request Tracing** | UUID per request for incident investigation | Active |
 | **Password Hashing** | Automatic bcrypt with dynamic salt | Active |
 | **Secrets Management** | Environment-based configuration, zero secrets in code | Active |
@@ -92,7 +92,7 @@ X-RateLimit-Reset: 1709582400
 
 ### 4. Audit Logging
 
-#### Comprehensive Event Tracking
+#### Event Tracking
 - **Location:** [`src/audit.py`](src/audit.py)
 - **Log File:** `audit.log` (JSON format)
 - **Retention:** Configure external log rotation
@@ -331,7 +331,7 @@ SECURITY: CORS allows all origins (*) in production!
 ## Compliance Mapping
 
 ### HIPAA 164.312(b) - Audit Controls
-**Met by**: Audit logging with comprehensive event tracking, JSON structured logs, request tracing
+**Met by**: Audit logging with structured event tracking, JSON structured logs, request tracing
 
 **Evidence:**
 - All authentication events logged
@@ -553,11 +553,11 @@ For security issues or questions:
 - 80% reduction in dependency attack surface for HS256 algorithm
 - Zero known vulnerabilities
 
-**v0.2.0 (2026-03-04)** - Comprehensive security hardening
+**v0.2.0 (2026-03-04)** - Security hardening
 - API key authentication with configurable enforcement
 - Per-IP rate limiting with slowapi
 - 7 security headers (including CSP, HSTS, X-Frame-Options)
-- Comprehensive audit logging with 22+ event types
+- Audit logging with 22+ event types
 - Request ID tracing for incident investigation
 - Secure error handling (environment-aware)
 - Environment-based secrets management

--- a/src/audit.py
+++ b/src/audit.py
@@ -1,6 +1,6 @@
 """Audit logging service for security and compliance tracking.
 
-This module provides comprehensive audit logging for:
+This module provides audit logging for:
 - HIPAA compliance evidence
 - SOC 2 control evidence (CC6.1, CC7.1, etc.)
 - Security incident investigation
@@ -145,7 +145,7 @@ def log_audit_event(
     level: AuditLevel = AuditLevel.INFO,
     success: bool = True,
 ) -> None:
-    """Log an auditable event with comprehensive context.
+    """Log an auditable event.
 
     This is the primary audit logging function. Call it for any security-relevant
     event that should be tracked for compliance, forensics, or monitoring.
@@ -208,7 +208,7 @@ def log_audit_event(
         )
     """
     # Build base log entry
-    log_entry = {
+    log_entry: dict[str, Any] = {
         "action": action.value,
         "success": success,
         "timestamp": datetime.now(UTC).isoformat(),

--- a/src/main.py
+++ b/src/main.py
@@ -1,11 +1,11 @@
-"""Main FastAPI application with comprehensive security hardening.
+"""Main FastAPI application.
 
 Security Features:
 - API key authentication (configurable)
 - Per-IP rate limiting (60 req/min default)
 - Security headers (HSTS, CSP, X-Frame-Options, etc.)
 - Request ID tracking for audit correlation
-- Comprehensive audit logging
+- Audit logging
 - Environment-aware CORS
 - Secure error handling (no info leakage in prod)
 

--- a/tests/test_comprehensive.py
+++ b/tests/test_comprehensive.py
@@ -1,4 +1,4 @@
-"""Comprehensive tests for CharlottesWeb API - Phase 3 test coverage expansion."""
+"""Tests for CharlottesWeb API - Phase 3 test coverage expansion."""
 
 from unittest.mock import patch
 
@@ -16,7 +16,7 @@ from src.models import (
 
 @pytest.fixture(scope="function")
 def test_db(tmp_path):
-    """Create a test database with comprehensive seeding."""
+    """Create a test database with seed data."""
     db_file = tmp_path / "test.db"
     test_db_url = f"sqlite:///{db_file}"
 
@@ -25,7 +25,7 @@ def test_db(tmp_path):
 
     Base.metadata.create_all(bind=engine)
 
-    # Seed controls comprehensively
+    # Seed all controls
     db = testing_session_local()
     controls = [
         Control(


### PR DESCRIPTION
- Remove 'comprehensive' from user-facing docs, docstrings, changelogs
- Remove 'For New Contributors or AI Agents' from README
- Rename 'What the Vertical Slice Demonstrates' to neutral section header
- Fix mypy: explicitly type audit log_entry as dict[str, Any]
- HIPAA regulatory language and config comments left unchanged