### PR TITLE
Use softer severity colors for dark mode

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -243,8 +243,8 @@
         }
 
         .result.error {
-            border-left: 4px solid #ef4444;
-            color: #fca5a5;
+            border-left: 4px solid #d946ef;
+            color: #f0abfc;
             background-color: #2d1b2e;
         }
 
@@ -260,22 +260,22 @@
             padding: 15px;
             margin-bottom: 12px;
             border-radius: 4px;
-            border-left: 4px solid #f59e0b;
+            border-left: 4px solid #e2a04d;
         }
 
         .finding-item.critical {
-            border-left-color: #ef4444;
-            background: #2d1b25;
+            border-left-color: #e06b6b;
+            background: #2d1f24;
         }
 
         .finding-item.high {
-            border-left-color: #f59e0b;
+            border-left-color: #e2a04d;
             background: #2d2520;
         }
 
         .finding-item.medium {
-            border-left-color: #eab308;
-            background: #2d2a1b;
+            border-left-color: #d4b94e;
+            background: #2d2a1e;
         }
 
         .cve-id {
@@ -295,18 +295,18 @@
         }
 
         .cvss-score.critical {
-            background: #ef4444;
+            background: #e06b6b;
             color: white;
         }
 
         .cvss-score.high {
-            background: #f59e0b;
-            color: #1a1a1a;
+            background: #e2a04d;
+            color: white;
         }
 
         .cvss-score.medium {
-            background: #eab308;
-            color: #1a1a1a;
+            background: #d4b94e;
+            color: #1e1b2e;
         }
 
         .cvss-score.low {
@@ -355,8 +355,8 @@
         .breach-example {
             margin-top: 8px;
             padding: 10px;
-            background: rgba(239, 68, 68, 0.15);
-            border: 1px solid rgba(239, 68, 68, 0.3);
+            background: rgba(224, 107, 107, 0.15);
+            border: 1px solid rgba(224, 107, 107, 0.3);
             border-radius: 4px;
             font-size: 12px;
         }
@@ -493,9 +493,9 @@
         }
 
         .component-row button {
-            color: #f87171;
+            color: #d946ef;
             background: #2a2440;
-            border: 2px solid #f87171;
+            border: 2px solid #d946ef;
             margin: 0;
             padding: 10px;
             font-size: 14px;
@@ -505,7 +505,7 @@
         }
 
         .component-row button:hover {
-            background: #f87171;
+            background: #d946ef;
             color: #1e1b2e;
         }
 
@@ -715,7 +715,7 @@
 
                     <div style="display: flex; gap: 8px; margin-top: 8px;">
                         <button type="button" id="mergeManifestBtn" style="flex: 1; background: #6b3fa0; color: #fff; border: none; padding: 8px 12px; border-radius: 4px; cursor: pointer; font-weight: 600;">Merge into List</button>
-                        <button type="button" id="replaceManifestBtn" style="flex: 1; background: #ef4444; color: #fff; border: none; padding: 8px 12px; border-radius: 4px; cursor: pointer; font-weight: 600;">Replace List</button>
+                        <button type="button" id="replaceManifestBtn" style="flex: 1; background: #d946ef; color: #fff; border: none; padding: 8px 12px; border-radius: 4px; cursor: pointer; font-weight: 600;">Replace List</button>
                     </div>
                     <div class="help-text" style="margin-top: 6px;"><strong>Merge</strong> adds new components and updates versions of existing ones. <strong>Replace</strong> clears the list first.</div>
                 </div>
@@ -1973,7 +1973,7 @@
                     window.currentAssessment.filteredFindings = filteredFindings;
                 }
             } catch (error) {
-                container.innerHTML = '<p style="color:#f87171;">Failed to apply filters. Please try again.</p>';
+                container.innerHTML = '<p style="color:#f0abfc;">Failed to apply filters. Please try again.</p>';
             }
         }
 
@@ -2325,7 +2325,7 @@
                     });
                 });
             } catch (error) {
-                actionPlanPanel.innerHTML = `<p style="color: #f87171; margin: 0;">❌ Could not load action plan. Please try again.</p>`;
+                actionPlanPanel.innerHTML = `<p style="color: #f0abfc; margin: 0;">❌ Could not load action plan. Please try again.</p>`;
                 actionPlanLink.setAttribute('aria-expanded', 'false');
                 actionPlanLink.textContent = 'View Action Plan';
             }


### PR DESCRIPTION
## Summary
- Revert vulnerability severity indicators (finding borders, CVSS badges, breach examples) from purple back to muted red/orange/yellow/green suitable for dark mode
- Keep Replace List button and component X button as purple (#d946ef) accents

## Test plan
- [ ] Verify critical findings show softer red (#e06b6b)
- [ ] Verify high findings show softer orange (#e2a04d)
- [ ] Verify medium findings show softer yellow (#d4b94e)
- [ ] Verify low findings remain green (#10b981)
- [ ] Verify Replace List button and X button remain purple