### PR TITLE
Harden input validation and sanitization

### DIFF
--- a/src/audit.py
+++ b/src/audit.py
@@ -35,6 +35,8 @@ from typing import Any
 
 from fastapi import Request
 
+from src.utils import sanitize_log_value
+
 # Configure dedicated audit logger (separate from application logs)
 # Name: "audit" - allows separation in log aggregation systems
 audit_logger = logging.getLogger("audit")
@@ -224,8 +226,12 @@ def log_audit_event(
             ),  # From RequestIDMiddleware
             "ip": request.client.host if request.client else None,  # Source IP
             "method": request.method,  # HTTP method (GET, POST, etc.)
-            "path": str(request.url.path),  # Request path (don't include query params)
-            "user_agent": request.headers.get("user-agent"),  # Client identification
+            "path": sanitize_log_value(
+                str(request.url.path), max_length=500
+            ),  # Request path (don't include query params)
+            "user_agent": sanitize_log_value(
+                request.headers.get("user-agent", ""), max_length=500
+            ),  # Client identification
         }
 
     # User identification (for user-specific actions)

--- a/src/osv_service.py
+++ b/src/osv_service.py
@@ -7,6 +7,8 @@ from typing import Any, TypedDict
 
 import requests
 
+from src.utils import sanitize_log_value
+
 logger = logging.getLogger(__name__)
 
 
@@ -162,7 +164,11 @@ class OSVService:
                     raise last_error
 
                 if response.status_code == 400:
-                    raise OSVApiError(f"OSV API bad request: {response.text}")
+                    logger.warning(
+                        "OSV API 400 response: %s",
+                        sanitize_log_value(response.text),
+                    )
+                    raise OSVApiError("OSV API bad request (invalid query parameters)")
 
                 response.raise_for_status()
                 return response.json()
@@ -289,9 +295,9 @@ class OSVService:
 
         logger.info(
             "OSV query: %s/%s@%s → %d vulnerabilities",
-            ecosystem,
-            name,
-            version,
+            sanitize_log_value(ecosystem),
+            sanitize_log_value(name),
+            sanitize_log_value(version),
             len(all_vulns),
         )
         return all_vulns

--- a/src/routers/components.py
+++ b/src/routers/components.py
@@ -31,7 +31,7 @@ def suggest_component_names(
         Dictionary with a list of suggested component names
     """
     prefix_normalized = prefix.lower().strip()
-    if len(prefix_normalized) < 2:
+    if len(prefix_normalized) < 2 or len(prefix_normalized) > 100:
         return {"components": []}
 
     bounded_limit = max(1, min(limit, 20))
@@ -65,7 +65,7 @@ def get_component_versions(
     """
     component_lower = component_name.lower().strip()
 
-    if not component_lower or len(component_lower) < 2:
+    if not component_lower or len(component_lower) < 2 or len(component_lower) > 100:
         return {"versions": []}
 
     # Fetch a large set so prefix filtering has enough to work with

--- a/src/routers/organizations.py
+++ b/src/routers/organizations.py
@@ -19,10 +19,11 @@ from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from src.audit import AuditAction, log_audit_event
+from src.cache import ai_threat_model_cache, nvd_cache
 from src.config import settings
 from src.database import get_db, get_or_404
 from src.middleware import get_api_key_optional, limiter
-from src.models import CacheEntry, Evidence, Organization, OrganizationMember
+from src.models import Evidence, Organization, OrganizationMember
 from src.schemas import (
     OrganizationCreate,
     OrganizationOnboardingCreate,
@@ -205,11 +206,11 @@ def delete_organization(
         # Evidence has a direct FK to organizations (not covered by ORM cascade)
         db.query(Evidence).filter(Evidence.organization_id == org_id).delete()
 
-        # Purge cached AI threat models / vulnerability results for this org so no
-        # stale data lingers after the org is removed.
-        db.query(CacheEntry).filter(CacheEntry.key.contains(org_id)).delete(
-            synchronize_session="fetch"
-        )
+        # Purge cached AI threat models / vulnerability results for this org.
+        # Clear entire namespaces rather than substring-matching org_id in keys,
+        # which could over-delete unrelated entries (CWE-943).
+        nvd_cache.invalidate(key=None, db=db)
+        ai_threat_model_cache.invalidate(key=None, db=db)
 
         db.delete(org)
         db.commit()

--- a/src/routers/reports.py
+++ b/src/routers/reports.py
@@ -238,6 +238,11 @@ def download_assessment_report(
     if not report_path.exists():
         raise HTTPException(status_code=404, detail="Report file not found")
 
+    # Guard against path traversal — report must be inside expected directory.
+    expected_dir = REPORT_OUTPUT_DIR.resolve()
+    if not report_path.resolve().is_relative_to(expected_dir):
+        raise HTTPException(status_code=403, detail="Invalid report path")
+
     log_audit_event(
         action=AuditAction.DATA_READ,
         request=request,

--- a/src/routers/vulnerability_analysis.py
+++ b/src/routers/vulnerability_analysis.py
@@ -20,7 +20,7 @@ from src.models import Assessment, Control, Evidence, Finding, MetadataProfile
 from src.osv_service import OSVApiError, OSVService
 from src.rules_engine import normalize_software_stack
 from src.schemas import FindingResponse
-from src.utils import to_float, to_str, to_str_list
+from src.utils import sanitize_log_value, to_float, to_str, to_str_list
 
 router = APIRouter(prefix="/assessments", tags=["assessments"])
 logger = logging.getLogger(__name__)
@@ -392,12 +392,15 @@ def analyze_nvd_vulnerabilities(
                 resource_id=assessment_id,
                 details={
                     "status": "error",
-                    "reason": str(e),
+                    "reason": sanitize_log_value(str(e)),
                     "software_stack_components": len(components),
                 },
                 level=AuditLevel.ERROR,
             )
-            raise HTTPException(status_code=503, detail=str(e)) from e
+            raise HTTPException(
+                status_code=503,
+                detail="Vulnerability scanning service temporarily unavailable",
+            ) from e
 
         osv_results = {
             comp_key: [cast(dict[str, Any], v) for v in vulns]

--- a/src/rules_engine.py
+++ b/src/rules_engine.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session
 
 from src.models import Assessment, Control, Finding, MetadataProfile
 from src.osv_service import OSVApiError, OSVService
+from src.utils import sanitize_log_value
 
 logger = logging.getLogger(__name__)
 
@@ -380,6 +381,10 @@ class RulesEngine:
                     owner="DevOps",
                 )
                 findings.append(finding)
-                logger.info("Created finding for %s in %s", display_id, component_key)
+                logger.info(
+                    "Created finding for %s in %s",
+                    sanitize_log_value(display_id),
+                    sanitize_log_value(component_key),
+                )
 
         return findings

--- a/src/utils.py
+++ b/src/utils.py
@@ -117,6 +117,21 @@ def sanitize_filename(filename: str, *, max_length: int = 255) -> str:
     return filename
 
 
+def sanitize_log_value(value: str, *, max_length: int = 200) -> str:
+    """Sanitize a value before including it in log messages.
+
+    Strips newlines, carriage returns, and control characters to prevent
+    log injection attacks (CWE-117).  Truncates to *max_length* so a
+    single malicious field cannot bloat log storage.
+    """
+    value = str(value)
+    value = _CONTROL_CHAR_RE.sub("", value)
+    value = value.replace("\n", "\\n").replace("\r", "\\r")
+    if len(value) > max_length:
+        value = value[:max_length] + "...[truncated]"
+    return value
+
+
 def escape_for_html(text: str) -> str:
     """HTML-escape a string for safe rendering in innerHTML contexts."""
     return html.escape(str(text), quote=True)


### PR DESCRIPTION
## Summary
* Add `sanitize_log_value()` utility to prevent log injection (CWE-117) and apply it to all user-controlled values reaching logger calls
* Stop echoing raw external API error messages to clients (CWE-209)
* Replace unsafe `.contains(org_id)` cache deletion with namespace-level invalidation (CWE-943)
* Add path traversal guard on report file downloads (CWE-22)
* Cap component prefix/name query params at 100 chars

## Test plan
* [ ] Verify "Lint and Tests" CI passes (108 tests)
* [ ] Confirm OSV vulnerability scan still works end-to-end
* [ ] Confirm org deletion still purges cached data
* [ ] Confirm report download still works for valid reports
* [ ] Verify component autocomplete rejects oversized input