### PR TITLE
fix: sanitize all remaining log injection vectors (CWE-117)

### DIFF
--- a/src/ai_threat_model_service.py
+++ b/src/ai_threat_model_service.py
@@ -29,7 +29,7 @@ from sqlalchemy.orm import Session
 
 from src.config import settings
 from src.models import Assessment, Control, Finding, MetadataProfile
-from src.utils import to_str
+from src.utils import sanitize_log_value, to_str
 
 logger = logging.getLogger(__name__)
 
@@ -318,8 +318,8 @@ def generate_ai_threat_model(
 
     logger.info(
         "Generating AI threat model for org=%s assessment=%s",
-        organization_id,
-        assessment_id_str,
+        sanitize_log_value(str(organization_id)),
+        sanitize_log_value(str(assessment_id_str)),
     )
 
     with client.messages.stream(
@@ -349,7 +349,9 @@ def generate_ai_threat_model(
     try:
         threat_model: dict[str, Any] = json.loads(result_text)
     except json.JSONDecodeError as e:
-        logger.error("Failed to parse AI threat model response: %s", e)
+        logger.error(
+            "Failed to parse AI threat model response: %s", sanitize_log_value(str(e))
+        )
         raise ValueError("AI model returned invalid JSON") from e
 
     # --- Attach metadata ---

--- a/src/audit.py
+++ b/src/audit.py
@@ -221,8 +221,8 @@ def log_audit_event(
     # Correlate with request ID for distributed tracing
     if request:
         log_entry["request"] = {
-            "id": getattr(
-                request.state, "request_id", None
+            "id": sanitize_log_value(
+                str(getattr(request.state, "request_id", ""))
             ),  # From RequestIDMiddleware
             "ip": request.client.host if request.client else None,  # Source IP
             "method": request.method,  # HTTP method (GET, POST, etc.)

--- a/src/dependabot_service.py
+++ b/src/dependabot_service.py
@@ -6,6 +6,8 @@ from typing import Any, cast
 
 import requests
 
+from src.utils import sanitize_log_value
+
 logger = logging.getLogger(__name__)
 
 
@@ -109,7 +111,10 @@ class DependabotService:
                     if parsed:
                         results.append(parsed)
                 except Exception as e:
-                    logger.warning("Failed to parse dependabot alert: %s", e)
+                    logger.warning(
+                        "Failed to parse dependabot alert: %s",
+                        sanitize_log_value(str(e)),
+                    )
                     continue
 
             # Cache results
@@ -118,10 +123,12 @@ class DependabotService:
             return results
 
         except requests.exceptions.RequestException as e:
-            logger.error("GitHub API request failed: %s", e)
+            logger.error("GitHub API request failed: %s", sanitize_log_value(str(e)))
             return []
         except Exception as e:
-            logger.error("Error processing Dependabot response: %s", e)
+            logger.error(
+                "Error processing Dependabot response: %s", sanitize_log_value(str(e))
+            )
             return []
 
     def _parse_alert(self, alert: dict[str, Any]) -> dict[str, Any] | None:
@@ -178,7 +185,9 @@ class DependabotService:
             }
 
         except Exception as e:
-            logger.warning("Error parsing dependabot alert: %s", e)
+            logger.warning(
+                "Error parsing dependabot alert: %s", sanitize_log_value(str(e))
+            )
             return None
 
     def _infer_cwes(self, package_name: str, description: str) -> list[str]:

--- a/src/main.py
+++ b/src/main.py
@@ -51,6 +51,7 @@ from src.models import (
     Organization,
     OrganizationMember,
 )
+from src.utils import sanitize_log_value
 
 logger = logging.getLogger(__name__)
 
@@ -418,7 +419,7 @@ except Exception as e:
     # Log static file mounting error but continue (API still works)
     logger.warning(
         "Failed to mount static files: %s. Web UI will not be available.",
-        e,
+        sanitize_log_value(str(e)),
     )
 
 

--- a/src/mitre_service.py
+++ b/src/mitre_service.py
@@ -19,6 +19,8 @@ from typing import Any
 
 import requests
 
+from src.utils import sanitize_log_value
+
 logger = logging.getLogger(__name__)
 
 
@@ -135,7 +137,9 @@ class MITREService:
             return data
 
         except requests.exceptions.RequestException as e:
-            logger.error("Failed to fetch MITRE ATT&CK data: %s", e)
+            logger.error(
+                "Failed to fetch MITRE ATT&CK data: %s", sanitize_log_value(str(e))
+            )
             # Return empty structure if fetch fails
             return {"objects": []}
 

--- a/src/nvd_service.py
+++ b/src/nvd_service.py
@@ -86,7 +86,7 @@ class NVDService:
                     "NVD API request failed (attempt %d/%d): %s",
                     attempt + 1,
                     attempts,
-                    e,
+                    sanitize_log_value(str(e)),
                 )
                 if attempt < attempts - 1:
                     time.sleep(RATE_LIMIT_BACKOFF_SECONDS)
@@ -239,7 +239,9 @@ class NVDService:
             )
             return []
         except Exception as e:
-            logger.error("Error fetching versions from NVD: %s", e)
+            logger.error(
+                "Error fetching versions from NVD: %s", sanitize_log_value(str(e))
+            )
             return []
 
     def get_component_suggestions(
@@ -314,7 +316,7 @@ class NVDService:
             logger.info(
                 "Extracted %d component suggestions for prefix: %s",
                 len(top_components),
-                normalized_prefix,
+                sanitize_log_value(normalized_prefix),
             )
             return top_components
 
@@ -325,5 +327,8 @@ class NVDService:
             )
             return []
         except Exception as e:
-            logger.error("Error extracting component suggestions from NVD: %s", e)
+            logger.error(
+                "Error extracting component suggestions from NVD: %s",
+                sanitize_log_value(str(e)),
+            )
             return []

--- a/src/osv_service.py
+++ b/src/osv_service.py
@@ -179,7 +179,7 @@ class OSVService:
                     "OSV API request failed (attempt %d/%d): %s",
                     attempt + 1,
                     attempts,
-                    e,
+                    sanitize_log_value(str(e)),
                 )
                 if attempt < attempts - 1:
                     time.sleep(RETRY_BACKOFF_SECONDS * (attempt + 1))
@@ -328,7 +328,10 @@ class OSVService:
             ecosystem = comp.get("ecosystem", "")
 
             if not name or not version:
-                logger.warning("Skipping component with missing fields: %s", comp)
+                logger.warning(
+                    "Skipping component with missing fields: %s",
+                    sanitize_log_value(str(comp)),
+                )
                 continue
 
             component_key = f"{name}@{version}"
@@ -339,7 +342,9 @@ class OSVService:
                     results[component_key] = vulns
             except OSVApiError:
                 failed.append(component_key)
-                logger.error("OSV API failed for: %s", component_key)
+                logger.error(
+                    "OSV API failed for: %s", sanitize_log_value(component_key)
+                )
 
         if failed and not results:
             raise OSVApiError(
@@ -351,7 +356,7 @@ class OSVService:
             logger.warning(
                 "Partial OSV results: %d failed (%s), %d succeeded",
                 len(failed),
-                ", ".join(failed),
+                sanitize_log_value(", ".join(failed)),
                 len(results),
             )
 

--- a/src/routers/threat_model.py
+++ b/src/routers/threat_model.py
@@ -27,7 +27,7 @@ from src.config import settings
 from src.database import get_db
 from src.middleware import get_api_key_optional, limiter
 from src.models import Assessment, Finding, MetadataProfile
-from src.utils import to_str
+from src.utils import sanitize_log_value, to_str
 
 logger = logging.getLogger(__name__)
 
@@ -171,7 +171,10 @@ def get_ai_threat_model(
     if not force:
         cached = ai_threat_model_cache.get(cache_key, db)
         if cached is not None:
-            logger.info("AI threat model cache hit for org=%s", organization_id)
+            logger.info(
+                "AI threat model cache hit for org=%s",
+                sanitize_log_value(str(organization_id)),
+            )
             cached["_cached"] = True
             return cached
 


### PR DESCRIPTION
## Summary
- Sanitize 18 log statements across 8 files that were logging user-controlled or external input without `sanitize_log_value()`
- Covers: `X-Request-ID` header, URL path parameters, software stack component names/versions, and exception messages from external APIs (NVD, OSV, GitHub Dependabot, MITRE, Anthropic)
- Addresses CWE-117 (Log Injection) to prevent attackers from injecting fake log entries via newlines or control characters

## Test plan
- [x] Verified threat model generation works correctly
- [x] Verified vulnerability scanning returns results
- [x] Confirmed no functional behavior changes (only log output affected)
- [ ] CI lint and tests pass