### PR TITLE
chore(ci): group Dependabot updates, auto-merge minor/patch, add lock sync

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,16 @@ updates:
     ignore:
       - dependency-name: "fastapi"
         update-types: ["version-update:semver-major"]
+    # Combine all minor and patch bumps into a single weekly PR.
+    # Major bumps are left out of the group so they still arrive
+    # as individual PRs for deliberate review.
+    groups:
+      python_minor_and_patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"
@@ -38,3 +48,7 @@ updates:
       include: "scope"
     labels:
       - "ci/cd"
+    groups:
+      github_actions_all:
+        patterns:
+          - "*"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,28 @@
+name: Dependabot auto-merge
+
+# Automatically enables auto-merge on Dependabot pull requests for minor and
+# patch updates. GitHub then merges them once all required status checks pass,
+# including Lint and Tests and Lock File Sync. Major updates are intentionally
+# excluded so they require manual review.
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto_merge:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+
+      - name: Enable auto-merge for minor and patch updates
+        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch' }}
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-lock.yml
+++ b/.github/workflows/sync-lock.yml
@@ -1,0 +1,56 @@
+name: Sync requirements lock
+
+# Manually regenerate requirements.lock from requirements.txt and commit it
+# back to a branch. Run this on a Dependabot branch after requirements.txt
+# changes so the Lock File Sync check passes and auto-merge can proceed.
+#
+# Trigger from the Actions tab (Run workflow, pick the branch) or with:
+#   gh workflow run sync-lock.yml -f branch=BRANCH_NAME
+#
+# This uses the built in token, which has write access on a manual dispatch,
+# so no personal access token is required.
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to regenerate and commit the lock file on"
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  sync_lock:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout target branch
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+
+      - name: Install pip-tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install pip-tools
+
+      - name: Regenerate lock file
+        run: |
+          pip-compile --quiet --generate-hashes --no-annotate --output-file=requirements.lock requirements.txt
+
+      - name: Commit and push if the lock changed
+        run: |
+          if git diff --quiet requirements.lock; then
+            echo "Lock file already in sync. Nothing to commit."
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add requirements.lock
+            git commit -m "chore(deps): sync requirements.lock with requirements.txt"
+            git push origin HEAD:${{ inputs.branch }}
+          fi


### PR DESCRIPTION
## What this changes

Fixes the recurring Dependabot pileup, including the Lock File Sync block.

### Grouping
All minor and patch dependency bumps now arrive as one combined weekly PR instead of one per package. Major bumps stay as individual PRs for manual review. The existing fastapi major ignore is preserved.

### Auto-merge
A new workflow (`dependabot-auto-merge.yml`) enables auto-merge on Dependabot minor and patch PRs. GitHub merges them once all required checks pass (Lint and Tests, Lock File Sync, security scans). Major updates are excluded and stay manual.

### Lock file sync helper
The recurring block was that Dependabot bumps requirements.txt but never regenerates requirements.lock, so Lock File Sync fails on every runtime bump. New workflow `sync-lock.yml` regenerates the lock from requirements.txt and commits it back to a branch. It is manually dispatched, so it runs with the built in token (which has write access on manual dispatch) and needs no personal access token.

Flow for a weekly runtime PR: Dependabot opens the grouped PR, auto-merge is enabled, Lock File Sync fails, you run sync-lock on that branch, the lock is committed, all checks pass, and auto-merge fires.

### Requires
Repo setting "Allow auto-merge" must be enabled (being enabled separately).

### Note on full automation
Running the lock sync automatically on every Dependabot PR is possible but involves a security tradeoff (a workflow_run job with a write token that runs package build backends). I left that out so you can decide whether you want it. The manual dispatch is safe and, with grouping, only needed once per week.